### PR TITLE
Add eval.defer and task.suspend for trampolining

### DIFF
--- a/monix/shared/src/main/scala/org.atnos.eff.monix/TaskEffect.scala
+++ b/monix/shared/src/main/scala/org.atnos.eff.monix/TaskEffect.scala
@@ -37,6 +37,9 @@ trait TaskCreation {
   def async[R :_task, A](a: =>A): Eff[R, A] =
     send(Task.fork(Task.evalOnce(a)))
 
+  def suspend[R :_task, A](task: => Task[Eff[R, A]]): Eff[R, A] =
+    send[Task, R, Eff[R, A]](Task.suspend(task)).flatten
+
 }
 
 trait TaskInterpretation {

--- a/shared/src/main/scala/org/atnos/eff/EvalEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/EvalEffect.scala
@@ -33,6 +33,10 @@ trait EvalCreation extends EvalTypes {
 
   def delay[R :_eval, A](a: => A): Eff[R, A] =
     send(cats.Eval.later(a))
+
+  def defer[R :_eval, A](eff: => Eval[Eff[R, A]]): Eff[R, A] = {
+    send(cats.Eval.defer(eff)).flatten
+  }
 }
 
 trait EvalInterpretation extends EvalTypes {


### PR DESCRIPTION
Also found that the other test in `EvalEffectSpec` wasn't being executed.