### PR TITLE
Run callback on completion instead of on cancel

### DIFF
--- a/monix/shared/src/main/scala/org/atnos/eff/asyncmonix/AsyncTaskService.scala
+++ b/monix/shared/src/main/scala/org/atnos/eff/asyncmonix/AsyncTaskService.scala
@@ -38,8 +38,7 @@ case class AsyncTaskService() extends AsyncService {
         case Right(a) => c.onSuccess(a)
       }
 
-    val registerTask = (s: Scheduler, c: Callback[A]) =>
-      Cancelable(() => register(callback(c)))
+    val registerTask = { (_: Scheduler, c: Callback[A]) => register(callback(c)); Cancelable.empty }
 
     create(Task.async(registerTask), timeout)
   }


### PR DESCRIPTION
`AsyncTaskService.async` runs the callback on task cancel, not on task completion. This is a fix for that.