### PR TITLE
Add flatTraverseA and flatSequenceA

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
@@ -142,8 +142,11 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
   def traverseEff = {
     val traversed: Eff[Fx.fx1[Option], List[Int]] =
       List(1, 2, 3).traverseA(i => OptionEffect.some(i))
+    val flatTraversed: Eff[Fx.fx1[Option], List[Int]] =
+      List(1, 2, 3).flatTraverseA(i => OptionEffect.some(List(i, i + 1)))
 
-    traversed.runOption.run === Option(List(1, 2, 3))
+    traversed.runOption.run === Option(List(1, 2, 3)) &&
+      flatTraversed.runOption.run === Option(List(1, 2, 2, 3, 3, 4))
   }
 
   def functionReader[R, U, A, B](f: A => Eff[R, B])(implicit into: IntoPoly[R, U],

--- a/shared/src/main/scala/org/atnos/eff/Eff.scala
+++ b/shared/src/main/scala/org/atnos/eff/Eff.scala
@@ -351,9 +351,17 @@ trait EffCreation {
   def traverseA[R, F[_] : Traverse, A, B](fs: F[A])(f: A => Eff[R, B]): Eff[R, F[B]] =
     Traverse[F].traverse(fs)(f)(EffImplicits.EffApplicative[R])
 
-  /** use the applicative instance of Eff to sequenc a list of values */
+  /** use the applicative instance of Eff to sequence a list of values */
   def sequenceA[R, F[_] : Traverse, A](fs: F[Eff[R, A]]): Eff[R, F[A]] =
     Traverse[F].sequence(fs)(EffImplicits.EffApplicative[R])
+
+  /** use the applicative instance of Eff to traverse a list of values, then flatten it */
+  def flatTraverseA[R, F[_], A, B](fs: F[A])(f: A => Eff[R, F[B]])(implicit FT: Traverse[F], FM: FlatMap[F]): Eff[R, F[B]] =
+    FT.flatTraverse[Eff[R, ?], A, B](fs)(f)(EffImplicits.EffApplicative[R], FM)
+
+  /** use the applicative instance of Eff to sequence a list of values, then flatten it */
+  def flatSequenceA[R, F[_], A](fs: F[Eff[R, F[A]]])(implicit FT: Traverse[F], FM: FlatMap[F]): Eff[R, F[A]] =
+    FT.flatSequence[Eff[R, ?], A](fs)(EffImplicits.EffApplicative[R], FM)
 }
 
 object EffCreation extends EffCreation

--- a/shared/src/main/scala/org/atnos/eff/syntax/eff.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/eff.scala
@@ -20,6 +20,7 @@ trait eff {
   implicit final def toEffMonadicOps[R, M[_], A](e: Eff[R, M[A]]): EffMonadicOps[R, M, A] = new EffMonadicOps(e)
   implicit final def toEffApplicativeOps[F[_], A](values: F[A]): EffApplicativeOps[F, A] = new EffApplicativeOps(values)
   implicit final def toEffSequenceOps[F[_], R, A](values: F[Eff[R, A]]): EffSequenceOps[F, R, A] = new EffSequenceOps(values)
+  implicit final def toEffFlatSequenceOps[F[_], R, A](values: F[Eff[R, F[A]]]): EffFlatSequenceOps[F, R, A] = new EffFlatSequenceOps(values)
   implicit final def toEffApplicativeSyntaxOps[R, A](a: Eff[R, A]): EffApplicativeSyntaxOps[R, A] = new EffApplicativeSyntaxOps(a)
 }
 
@@ -80,11 +81,18 @@ final class EffMonadicOps[R, M[_], A](val e: Eff[R, M[A]]) extends AnyVal {
 final class EffApplicativeOps[F[_], A](val values: F[A]) extends AnyVal {
   def traverseA[R, B](f: A => Eff[R, B])(implicit F: Traverse[F]): Eff[R, F[B]] =
     Eff.traverseA(values)(f)
+  def flatTraverseA[R, B](f: A => Eff[R, F[B]])(implicit F1: Traverse[F], F2: FlatMap[F]): Eff[R, F[B]] =
+    Eff.flatTraverseA(values)(f)
 }
 
 final class EffSequenceOps[F[_], R, A](val values: F[Eff[R, A]]) extends AnyVal {
   def sequenceA(implicit F: Traverse[F]): Eff[R, F[A]] =
     Eff.sequenceA(values)
+}
+
+final class EffFlatSequenceOps[F[_], R, A](val values: F[Eff[R, F[A]]]) extends AnyVal {
+  def flatSequenceA(implicit F1: Traverse[F], F2: FlatMap[F]): Eff[R, F[A]] =
+    Eff.flatSequenceA(values)
 }
 
 final class EffApplicativeSyntaxOps[R, A](val a: Eff[R, A]) extends AnyVal {


### PR DESCRIPTION
Adds the `flatTraverseA` and `flatSequenceA` operators based on the `flatTraverse` and `flatSequence` operators in cats.